### PR TITLE
均等に負荷分散するため、v2.2.0で導入されたmoduloを使う

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'activerecord-turntable', '~> 2.1.1'
+gem 'activerecord-turntable', '~> 2.2.0'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,7 @@ GEM
       activemodel (= 4.2.1)
       activesupport (= 4.2.1)
       arel (~> 6.0)
-    activerecord-turntable (2.1.1)
+    activerecord-turntable (2.2.0)
       activerecord (>= 4.0.0, < 5.0)
       activesupport (>= 4.0.0, < 5.0)
       bsearch (~> 1.5)
@@ -297,7 +297,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord-turntable (~> 2.1.1)
+  activerecord-turntable (~> 2.2.0)
   awesome_print
   better_errors
   bullet

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,7 @@ class UsersController < ApplicationController
   # GET /users
   # GET /users.json
   def index
-    @users = User.all
+    @users = User.all.sort # 各シャードの結果が単純にマージされるので、ソートが必要（DB側にソートさせる意味が無い）
   end
 
   # GET /users/1

--- a/config/turntable.yml
+++ b/config/turntable.yml
@@ -5,18 +5,15 @@
 development:
   clusters:
     user_cluster:
-      algorithm: range_bsearch
+      algorithm: modulo
       seq:
         user_seq:
           seq_type: mysql
           connection: user_seq_1
       shards:
         - connection: user_shard_1
-          less_than: 10
         - connection: user_shard_2
-          less_than: 20
         - connection: user_shard_3
-          less_than: 30
 
 test:
   clusters:


### PR DESCRIPTION
新規ユーザが増えるたびに、shard_1 -> shard_2 -> shard_3 -> shard_1 -> shard_2 -> ... と振り分けられていかないと均等に負荷が掛からないので、moduloアルゴリズム（単純に剰余で振り分けているだけ）に変更しました。また、シャード全体にallでリクエストした際は、各シャードの結果をとりまとめた後でソートする必要がありました。
